### PR TITLE
chore: unpin versions from .in file (keeping pinned in .txt file)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
-aiohttp==3.9.0
-python-dateutil==2.8.1
+aiohttp
+python-dateutil


### PR DESCRIPTION
Having the versions in the .in file doesn't give anything but trouble when upgrading - the actual versions are pinned in .txt.